### PR TITLE
Allow en_GB as a local for KR and TW

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -30,12 +30,12 @@ const endpoints = {
   kr: {
     hostname: 'https://kr.api.battle.net',
     defaultLocale: 'ko_KR',
-    locales: ['ko_KR'],
+    locales: ['ko_KR', 'en_GB', 'en_US'],
   },
   tw: {
     hostname: 'https://tw.api.battle.net',
     defaultLocale: 'zh_TW',
-    locales: ['zh_TW'],
+    locales: ['zh_TW', 'en_GB', 'en_US'],
   },
   cn: {
     hostname: 'https://api.battlenet.com.cn',


### PR DESCRIPTION
Since it's working with the API:
https://tw.api.battle.net/wow/realm/status?locale=en_GB&apikey=***
It could be useful to have the choice to retrieve, for example, the server name in English.