### PR TITLE
Fixed namespace query missing on token requests

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -147,7 +147,9 @@ Data.prototype.region = function region (args, instance) {
  * @return {Promise}                  A thenable Promises/A+ reference
  */
 Data.prototype.token = function token (args, instance) {
-  return this.blizzard.get('/data/wow/token/', args, instance);
+  const params = { namespace: args.namespace || `dynamic-${args.origin}` };
+
+  return this.blizzard.get('/data/wow/token/', Object.assign({}, args, { params }), instance);
 };
 
 module.exports = Data;

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -144,7 +144,7 @@ describe('lib/data.js', () => {
 
   describe('#token()', () => {
     test('should request token data', () => {
-      blizzard.data.token();
+      blizzard.data.token({ origin: 'us' });
 
       expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
       expect(blizzard.axios.get).toHaveBeenCalledWith(


### PR DESCRIPTION
Relates to #56 and 0d16b2687d1590f762c82764b33ba794bbffd83b