### PR TITLE
updated d3 api to support new endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -384,10 +384,11 @@ blizzard.d3.era({ id: 5, leaderboard: 'rift-barbarian', origin: 'us' })
 Fetch a Diablo 3 profile.
 
 **Parameters**
-
+ * @param  {String} [args.itemTypes]    
 -   `args` Object
     -   `args.tag` String - The user battletag
     -   `args.hero` [Number] - The hero ID
+    -   `args.itemTypes` [String] - The hero items to fetch: `items`, `follower-items`
     -   `args.origin` [String] - The region key
     -   `args.locale` [String] - A locale code for this region
 -   `instance` [Object] - An axios instance configuration object

--- a/lib/d3.js
+++ b/lib/d3.js
@@ -60,19 +60,24 @@ D3.prototype.era = function era (args, instance) {
 /**
  * Fetch Diablo 3 profile data.
  *
- * @param  {Object} args          The profile request arguments
- * @param  {String} args.tag      The user battletag
- * @param  {String} [args.hero]   The hero name
- * @param  {String} [args.origin] The region key
- * @param  {String} [args.locale] A locale code for this region
- * @param  {Object} [instance]    An [axios](https://github.com/mzabriskie/axios) compatible instance configuration
- * @return {Promise}              A thenable Promises/A+ reference
+ * @param  {Object} args                The profile request arguments
+ * @param  {String} args.tag            The user battletag
+ * @param  {String} [args.hero]         The hero name
+ * @param  {String} [args.itemTypes]    The hero items to fetch {items, follower-items}
+ * @param  {String} [args.origin]       The region key
+ * @param  {String} [args.locale]       A locale code for this region
+ * @param  {Object} [instance]          An [axios](https://github.com/mzabriskie/axios) compatible instance configuration
+ * @return {Promise}                    A thenable Promises/A+ reference
  */
 D3.prototype.profile = function profile (args, instance) {
   const tag = this.blizzard.battletag(args.tag);
 
   if (!args.hero) {
     return this.blizzard.get(`/d3/profile/${tag}/`, args, instance);
+  }
+
+  if (args.hero && args.itemTypes) {
+    return this.blizzard.get(`/d3/profile/${tag}/hero/${args.hero}/${args.itemTypes}`, args, instance);
   }
 
   return this.blizzard.get(`/d3/profile/${tag}/hero/${args.hero}`, args, instance);

--- a/test/d3.test.js
+++ b/test/d3.test.js
@@ -131,6 +131,25 @@ describe('lib/d3.js', () => {
         expect.any(Object)
       );
     });
-  });
 
+    test('should request the correct hero profile with items', () => {
+      blizzard.d3.profile({ tag: 'skt#1884', hero: 287801, itemTypes: 'items' });
+
+      expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
+      expect(blizzard.axios.get).toHaveBeenCalledWith(
+        'https://us.api.battle.net/d3/profile/skt-1884/hero/287801/items',
+        expect.any(Object)
+      );
+    });
+
+    test('should request the correct hero profile with follower-items', () => {
+      blizzard.d3.profile({ tag: 'skt#1884', hero: 287801, itemTypes: 'follower-items' });
+
+      expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
+      expect(blizzard.axios.get).toHaveBeenCalledWith(
+        'https://us.api.battle.net/d3/profile/skt-1884/hero/287801/follower-items',
+        expect.any(Object)
+      );
+    });
+  });
 });


### PR DESCRIPTION
* updated d3 api to support new blizzard api endpoints

  - hero items:
    GET
    getApiDetailedHeroItems
    /d3/profile/{account}/hero/{heroId}/items

  - follower items:
    GET
    getApiDetailedFollowerItems
    /d3/profile/{account}/hero/{heroId}/follower-items