### PR TITLE
Fix initialized origin not being set as default

### DIFF
--- a/lib/blizzard.js
+++ b/lib/blizzard.js
@@ -132,7 +132,7 @@ Blizzard.prototype.get = function get (path, args, instance) {
   const config = Object.assign({}, args);
   const apikey = this.params(['apikey'], config);
   const access_token = this.params(['access_token'], config);
-  const endpoint = endpoints.getEndpoint(config.origin, config.locale || this.defaults.params.locale);
+  const endpoint = endpoints.getEndpoint(config.origin || this.defaults.origin, config.locale || this.defaults.params.locale);
   const params = Object.assign({}, this.defaults.params, config.params, apikey, access_token, { locale: endpoint.locale });
   const obj = Object.assign({}, this.instance, instance, { params });
 

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -51,10 +51,12 @@ const endpoints = {
  * @return {Endpoint}        The endpoint data object
  */
 exports.getEndpoint = function getEndpoint (key, locale) {
-  const endpoint = endpoints[key] || endpoints.us;
+  const validKey = endpoints.hasOwnProperty(key) ? key : 'us';
+  const endpoint = endpoints[validKey];
 
   return Object.assign(
     {},
+    { origin: validKey },
     { hostname: endpoint.hostname },
     { locale: endpoint.locales.find(item => item === locale) || endpoint.defaultLocale }
   );

--- a/test/__snapshots__/endpoints.test.js.snap
+++ b/test/__snapshots__/endpoints.test.js.snap
@@ -4,6 +4,7 @@ exports[`lib/endpoints.js #getEndpoint() should return the EU es_ES endpoint 1`]
 Object {
   "hostname": "https://eu.api.battle.net",
   "locale": "es_ES",
+  "origin": "eu",
 }
 `;
 
@@ -11,6 +12,7 @@ exports[`lib/endpoints.js #getEndpoint() should return the SEA endpoint 1`] = `
 Object {
   "hostname": "https://sea.api.battle.net",
   "locale": "en_US",
+  "origin": "sea",
 }
 `;
 
@@ -18,6 +20,7 @@ exports[`lib/endpoints.js #getEndpoint() should return the US endpoint 1`] = `
 Object {
   "hostname": "https://us.api.battle.net",
   "locale": "en_US",
+  "origin": "us",
 }
 `;
 
@@ -25,5 +28,6 @@ exports[`lib/endpoints.js #getEndpoint() should return the default endpoint 1`] 
 Object {
   "hostname": "https://us.api.battle.net",
   "locale": "en_US",
+  "origin": "us",
 }
 `;

--- a/test/blizzard.test.js
+++ b/test/blizzard.test.js
@@ -54,6 +54,32 @@ describe('lib/blizzard.js', () => {
     });
   });
 
+  describe('#get()', () => {
+    test('should be called with the correct parameters', () => {
+      blizzard.defaults.origin = 'eu';
+      blizzard.get('/wow/character/proudmoore/kailee', { origin: 'sea' });
+
+      expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
+      expect(blizzard.axios.get).toHaveBeenCalledWith(
+        'https://sea.api.battle.net/wow/character/proudmoore/kailee',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('#get()', () => {
+    test('should be called with the correct parameters', () => {
+      blizzard.defaults.origin = 'eu';
+      blizzard.get('/wow/character/proudmoore/kailee');
+
+      expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
+      expect(blizzard.axios.get).toHaveBeenCalledWith(
+        'https://eu.api.battle.net/wow/character/proudmoore/kailee',
+        expect.any(Object)
+      );
+    });
+  });
+
   describe('#all()', () => {
     test('should be called with the correct parameters', () => {
       const character = blizzard.get('/wow/character/amanthul/charni');


### PR DESCRIPTION
When initializing Blizzard with a provided origin it is not correctly
set as the default origin. Calling the API always requires an origin for
each call, otherwise it falls back to "us".

Update endpoints.js to set the valid regional key as origin in the
returned object.

Update blizzard.js to set defaults.origin to the value returned from the
default endpoint during initialization. Update get() to use
defaults.origin if no origin is provided in the function parameters.

Update endpoints.test.js.snap to include the origin being returned in
the endpoint object.

Update blizzard.test.js to test several scenarios of origin being
provided and not provided when calling the get() function.