### PR TITLE
User Characters don't need override for host

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -49,7 +49,6 @@ const endpoints = {
 function getPathHostName(origin, path) {
   const pathOverride = {
     '/oauth/userinfo': `https://${origin}.battle.net`,
-    '/wow/user/characters': `https://${origin}.battle.net`,
   };
 
   return Object.prototype.hasOwnProperty.call(pathOverride, path) ? pathOverride[path] : endpoints[origin].hostname;

--- a/test/wow.test.js
+++ b/test/wow.test.js
@@ -602,7 +602,7 @@ describe('lib/wow.js', () => {
 
       expect(blizzard.axios.get).toHaveBeenCalledTimes(1);
       expect(blizzard.axios.get).toHaveBeenCalledWith(
-        'https://us.battle.net/wow/user/characters',
+        'https://us.api.blizzard.com/wow/user/characters',
         expect.objectContaining(
           merge({}, args, {
             headers: {


### PR DESCRIPTION
Fix origin for `/wow/user/characters`, according to https://us.battle.net/forums/en/bnet/topic/20769607186

Resolves #81 