### PR TITLE
Change Get to Post for /oauth/token

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -118,7 +118,7 @@ export abstract class Blizzard implements BlizzardClient {
   }): Promise<AxiosResponse<AccessToken>> {
     const { origin, key, secret } = { ...this.defaults, ...args }
 
-    return this.axios.get(`https://${origin}.battle.net/oauth/token`, {
+    return this.axios.post(`https://${origin}.battle.net/oauth/token`, null, {
       params: { grant_type: 'client_credentials' },
       auth: {
         username: key,

--- a/test/__mocks__/axios.ts
+++ b/test/__mocks__/axios.ts
@@ -6,7 +6,7 @@ jest.unmock('axios')
 
 const mockAxios = new MockAdapter(axios)
 
-mockAxios.onGet('https://us.battle.net/oauth/token').reply(200, {
+mockAxios.onPost('https://us.battle.net/oauth/token').reply(200, {
   access_token: 'test_token',
   token_type: 'bearer',
   expires_in: 86400, // 1 day in seconds


### PR DESCRIPTION
Fixes #121 by updating the deprecated HTTP Get on the /oauth/token endpoint to post to the endpoint instead