### PR TITLE
Add sideboardCards param to HS deck endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blizzard.js",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "author": {
     "name": "Ben Weier",
     "email": "ben.weier@gmail.com",

--- a/src/resources/hs.ts
+++ b/src/resources/hs.ts
@@ -157,15 +157,28 @@ export const cardBacks = (
   }
 }
 
-export type DeckOptions = { code?: string; ids?: number | number[]; hero?: number }
+export type DeckOptions = {
+  code?: string
+  ids?: number | number[]
+  hero?: number
+  /**
+   * This unlisted parameter is used to add sideboard cards for Zilliax Deluxe 3000 and E.T.C., Band Manager.
+   * The accepted format is `sideboardCardId:primaryCardId`.
+   * Repeat this format for each sideboard card to be added.
+   */
+  sideboardCards?: `${number}:${number}` | `${number}:${number}`[]
+}
 
-export const deck = (args: DeckOptions): Resource<{ code?: string; ids?: number | string; hero?: number }> => {
+export const deck = (
+  args: DeckOptions,
+): Resource<{ code?: string; ids?: number | string; hero?: number; sideboardCards?: string }> => {
   return {
     path: 'hearthstone/deck',
     params: {
       code: args.code,
       ids: Array.isArray(args.ids) ? args.ids.join(',') : args.ids,
       hero: args.hero,
+      sideboardCards: Array.isArray(args.sideboardCards) ? args.sideboardCards.join(',') : args.sideboardCards,
     },
   }
 }

--- a/src/resources/hs.ts
+++ b/src/resources/hs.ts
@@ -13,9 +13,34 @@ export type CardClass =
   | 'warrior'
   | 'neutral'
 
-export type CardGameMode = 'constructed' | 'battlegrounds' | 'arena' | 'duels'
+export type CardGameMode = 'constructed' | 'battlegrounds' | 'arena' | 'mercenaries'
 
-export type CardMinionType = 'murloc' | 'demon' | 'mech' | 'elemental' | 'beast' | 'totem' | 'pirate' | 'dragon' | 'all'
+export type CardMinionType =
+  | 'bloodelf'
+  | 'draenei'
+  | 'dwarf'
+  | 'gnome'
+  | 'human'
+  | 'nightelf'
+  | 'orc'
+  | 'tauren'
+  | 'troll'
+  | 'undead'
+  | 'murloc'
+  | 'demon'
+  | 'mech'
+  | 'elemental'
+  | 'beast'
+  | 'totem'
+  | 'pirate'
+  | 'dragon'
+  | 'all'
+  | 'quilboar'
+  | 'halforc'
+  | 'naga'
+  | 'oldgod'
+  | 'pandaren'
+  | 'gronn'
 
 export type CardSortOrder = 'asc' | 'desc'
 
@@ -25,7 +50,7 @@ export type CardSortOption = 'manaCost' | 'attack' | 'health' | 'name' | 'dataAd
 
 export type CardTier = 1 | 2 | 3 | 4 | 5 | 6 | 'hero' | Array<1 | 2 | 3 | 4 | 5 | 6 | 'hero'>
 
-export type CardType = 'hero' | 'minion' | 'spell' | 'weapon'
+export type CardType = 'hero' | 'minion' | 'spell' | 'weapon' | 'hero power' | 'location' | 'baconquestreward'
 
 export type CardBackCategory =
   | 'base'
@@ -44,6 +69,8 @@ export type CardBackCategory =
 
 export type CardMetaDataType = 'sets' | 'setGroups' | 'types' | 'rarities' | 'classes' | 'minionTypes' | 'keywords'
 
+export type CardSpellSchools = 'arcane' | 'fire' | 'frost' | 'nature' | 'holy' | 'shadow' | 'fel'
+
 export type CardSearchOptions = {
   attack?: number | number[]
   class?: CardClass
@@ -53,12 +80,16 @@ export type CardSearchOptions = {
   keyword?: string
   manaCost?: number | number[]
   minionType?: CardMinionType
+  /**
+   * @deprecated use sort option instead
+   */
   order?: CardSortOrder
   page?: number
   pageSize?: number
   rarity?: CardRarity
   set?: string
   sort?: CardSortOption | `${CardSortOption}:${CardSortOrder}` | Array<`${CardSortOption}:${CardSortOrder}`>
+  spellSchool?: CardSpellSchools
   textFilter?: string
   tier?: CardTier
   type?: CardType
@@ -75,12 +106,12 @@ export const cardSearch = (
   keyword?: string
   manaCost?: number | string
   minionType?: CardMinionType
-  order?: CardSortOrder
   page?: number
   pageSize?: number
   rarity?: CardRarity
   set?: string
   sort?: string
+  spellSchool?: CardSpellSchools
   textFilter?: string
   tier?: number | 'hero' | string
   type?: CardType
@@ -96,12 +127,12 @@ export const cardSearch = (
       keyword: args.keyword,
       manaCost: Array.isArray(args.manaCost) ? args.manaCost.join(',') : args.manaCost,
       minionType: args.minionType,
-      order: args.order,
       page: args.page,
       pageSize: args.pageSize,
       rarity: args.rarity,
       set: args.set,
       sort: Array.isArray(args.sort) ? args.sort.join(',') : args.sort,
+      spellSchool: args.spellSchool,
       textFilter: args.textFilter,
       tier: Array.isArray(args.tier) ? args.tier.join(',') : args.tier,
       type: args.type,

--- a/src/resources/hs.ts
+++ b/src/resources/hs.ts
@@ -162,11 +162,11 @@ export type DeckOptions = {
   ids?: number | number[]
   hero?: number
   /**
-   * This unlisted parameter is used to add sideboard cards for Zilliax Deluxe 3000 and E.T.C., Band Manager.
+   * This parameter is used to add sideboard cards for Zilliax Deluxe 3000 and E.T.C., Band Manager.
    * The accepted format is `sideboardCardId:primaryCardId`.
    * Repeat this format for each sideboard card to be added.
    */
-  sideboardCards?: `${number}:${number}` | `${number}:${number}`[]
+  sideboardCards?: string | string[]
 }
 
 export const deck = (


### PR DESCRIPTION
 This unlisted parameter is used to add sideboard cards for **Zilliax Deluxe 3000** and **E.T.C., Band Manager**.
 The accepted format is `sideboardCardId:primaryCardId`.
 
 When used, response includes a field `sideboardCards` of a type `[sideboardCard: Card, cardsInSideboard: Card[]]`.