### PR TITLE
Add sideboardCards param to HS deck endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blizzard.js",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "author": {
     "name": "Ben Weier",
     "email": "ben.weier@gmail.com",

--- a/src/resources/hs.ts
+++ b/src/resources/hs.ts
@@ -157,7 +157,17 @@ export const cardBacks = (
   }
 }
 
-export type DeckOptions = { code?: string; ids?: number | number[]; hero?: number; sideboardCards?: string | string[] }
+export type DeckOptions = {
+  code?: string
+  ids?: number | number[]
+  hero?: number
+  /**
+   * This unlisted parameter is used to add sideboard cards for Zilliax Deluxe 3000 and E.T.C., Band Manager.
+   * The accepted format is `sideboardCardId:primaryCardId`.
+   * Repeat this format for each sideboard card to be added.
+   */
+  sideboardCards?: `${number}:${number}` | `${number}:${number}`[]
+}
 
 export const deck = (
   args: DeckOptions,

--- a/src/resources/hs.ts
+++ b/src/resources/hs.ts
@@ -157,15 +157,18 @@ export const cardBacks = (
   }
 }
 
-export type DeckOptions = { code?: string; ids?: number | number[]; hero?: number }
+export type DeckOptions = { code?: string; ids?: number | number[]; hero?: number; sideboardCards?: string | string[] }
 
-export const deck = (args: DeckOptions): Resource<{ code?: string; ids?: number | string; hero?: number }> => {
+export const deck = (
+  args: DeckOptions,
+): Resource<{ code?: string; ids?: number | string; hero?: number; sideboardCards?: string }> => {
   return {
     path: 'hearthstone/deck',
     params: {
       code: args.code,
       ids: Array.isArray(args.ids) ? args.ids.join(',') : args.ids,
       hero: args.hero,
+      sideboardCards: Array.isArray(args.sideboardCards) ? args.sideboardCards.join(',') : args.sideboardCards,
     },
   }
 }


### PR DESCRIPTION
 This unlisted parameter is used to add sideboard cards for **Zilliax Deluxe 3000** and **E.T.C., Band Manager**.
 The accepted format is `sideboardCardId:primaryCardId`.
 
 When used, response includes a field `sideboardCards` of a type `[sideboardCard: Card, cardsInSideboard: Card[]]`.